### PR TITLE
Implement chat presence notification

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -1,4 +1,5 @@
 [
     "addUserStatuses",
-    "profileHoverCards"
+    "profileHoverCards",
+    "chatPresenceNotify"
 ]

--- a/addons/chatPresenceNotify/addon.js
+++ b/addons/chatPresenceNotify/addon.js
@@ -1,45 +1,16 @@
-var isWasteof3 = /beta/.test(new URL(document.URL).host);
-var userName = document.querySelector(isWasteof3 ? "a.mx-2 > span:nth-child(2)" : "span.hidden:nth-child(2)").innerText;
-var unloaded = true;
-var _unloaded = unloaded;
-var socket;
-
-function sendMessage(message) {
-    // ok I found it
-    console.log(socket);
-    socket.emit("message", message);
-}
-
-function onUnload() {
-    console.log("unloaded!");
-    unloaded = true;
-    sendMessage(`<i>${userName} leaves the chat.</i>`);
-}
-
-function onLoad() {
-    console.log("loaded!");
-    unloaded = false;
-    sendMessage(`<i>${userName} enters the chat.</i>`);
-}
-
-function checkLocation() {
-    unloaded = !(window.location.pathname == "/chat");
-    if (_unloaded != unloaded) {
-        [onLoad, onUnload][+unloaded](); // a cursed if block
-        _unloaded = unloaded;
-    }
-}
-
 function addon() {
-    window.onbeforeunload = onUnload;
-    console.log("made it here :)");
-    // set socket
-    console.log(window);
-    // FIXME: Seems like the `window` here doesn't have either `socket` or `$nuxt`...
-    socket = isWasteof3 ? window.socket : window.$nuxt.$socket;
-    if (socket === undefined) throw Error("socket is undefined");
-    setInterval(checkLocation, 1000)
+    console.log("executing addon , chatPresenceNotify");
+    const SCRIPT_ID = "chat-presence-notify";
+    // HACK: inject the notify.js script (because that's the only solution I can find)
+    if (document.getElementById(SCRIPT_ID) !== null) { // make sure this script isn't there already
+        console.log("script already exists");
+        return; 
+    }
+    let element = document.createElement("script");
+    element.id = SCRIPT_ID;
+    element.src = chrome.runtime.getURL('./addons/chatPresenceNotify/lib/notify.js');
+    console.log("injecting to", document.head, element);
+    document.head.appendChild(element);
 }
 
 addon();
-

--- a/addons/chatPresenceNotify/addon.js
+++ b/addons/chatPresenceNotify/addon.js
@@ -1,25 +1,23 @@
-console.log("made it here :)");
-const isWasteof3 = /beta/.test(new URL(document.URL).host);
-let userName = document.querySelector(isWasteof3 ? "a.mx-2 > span:nth-child(2)" : "span.hidden:nth-child(2)").innerText;
-let unloaded = true;
-let _unloaded = unloaded;
-let socket;
+var isWasteof3 = /beta/.test(new URL(document.URL).host);
+var userName = document.querySelector(isWasteof3 ? "a.mx-2 > span:nth-child(2)" : "span.hidden:nth-child(2)").innerText;
+var unloaded = true;
+var _unloaded = unloaded;
+var socket;
 
 function sendMessage(message) {
     // ok I found it
+    console.log(socket);
     socket.emit("message", message);
 }
 
 function onUnload() {
     console.log("unloaded!");
-    if (unloaded) return; // already outside /chat
     unloaded = true;
     sendMessage(`<i>${userName} leaves the chat.</i>`);
 }
 
 function onLoad() {
     console.log("loaded!");
-    if (!unloaded) return; // already inside /chat
     unloaded = false;
     sendMessage(`<i>${userName} enters the chat.</i>`);
 }
@@ -27,16 +25,21 @@ function onLoad() {
 function checkLocation() {
     unloaded = !(window.location.pathname == "/chat");
     if (_unloaded != unloaded) {
-        _unloaded = unloaded;
         [onLoad, onUnload][+unloaded](); // a cursed if block
+        _unloaded = unloaded;
     }
 }
 
 function addon() {
+    window.onbeforeunload = onUnload;
+    console.log("made it here :)");
     // set socket
+    console.log(window);
+    // FIXME: Seems like the `window` here doesn't have either `socket` or `$nuxt`...
     socket = isWasteof3 ? window.socket : window.$nuxt.$socket;
+    if (socket === undefined) throw Error("socket is undefined");
     setInterval(checkLocation, 1000)
 }
 
-document.addEventListener("beforeunload", onUnload);
-document.addEventListener("load", addon); // imagine addon() is here
+addon();
+

--- a/addons/chatPresenceNotify/addon.js
+++ b/addons/chatPresenceNotify/addon.js
@@ -1,0 +1,42 @@
+console.log("made it here :)");
+const isWasteof3 = /beta/.test(new URL(document.URL).host);
+let userName = document.querySelector(isWasteof3 ? "a.mx-2 > span:nth-child(2)" : "span.hidden:nth-child(2)").innerText;
+let unloaded = true;
+let _unloaded = unloaded;
+let socket;
+
+function sendMessage(message) {
+    // ok I found it
+    socket.emit("message", message);
+}
+
+function onUnload() {
+    console.log("unloaded!");
+    if (unloaded) return; // already outside /chat
+    unloaded = true;
+    sendMessage(`<i>${userName} leaves the chat.</i>`);
+}
+
+function onLoad() {
+    console.log("loaded!");
+    if (!unloaded) return; // already inside /chat
+    unloaded = false;
+    sendMessage(`<i>${userName} enters the chat.</i>`);
+}
+
+function checkLocation() {
+    unloaded = !(window.location.pathname == "/chat");
+    if (_unloaded != unloaded) {
+        _unloaded = unloaded;
+        [onLoad, onUnload][+unloaded](); // a cursed if block
+    }
+}
+
+function addon() {
+    // set socket
+    socket = isWasteof3 ? window.socket : window.$nuxt.$socket;
+    setInterval(checkLocation, 1000)
+}
+
+document.addEventListener("beforeunload", onUnload);
+document.addEventListener("load", addon); // imagine addon() is here

--- a/addons/chatPresenceNotify/addon.json
+++ b/addons/chatPresenceNotify/addon.json
@@ -1,0 +1,16 @@
+{
+    "urls": [
+        "https://wasteof.money/",
+        "https://wasteof.money",
+        "https://beta.wasteof.money/",
+        "https://beta.wasteof.money"
+    ],
+    "urlcontains": [
+        "wasteof.money/chat"
+    ],
+    "name": "Chat Presence Notifier",
+    "description": "Notifies users that they are entering/leaving chat",
+    "developers": [
+        {"name": "Gilbert189", "link": "https://beta.wasteof.money/users/gilbert189"}
+    ]
+}

--- a/addons/chatPresenceNotify/lib/notify.js
+++ b/addons/chatPresenceNotify/lib/notify.js
@@ -1,0 +1,48 @@
+let isWasteof3 = /beta/.test(new URL(document.URL).host);
+let userName = document.querySelector(isWasteof3 ? "a.mx-2 > span:nth-child(2)" : "span.hidden:nth-child(2)").innerText;
+let unloaded = true;
+let _unloaded = unloaded;
+let socket;
+
+function sendMessage(message) {
+    // ok I found it
+    console.log(socket);
+    socket.emit("message", message);
+}
+
+function onUnload() {
+    unloaded = true;
+    sendMessage(`<i>${userName} leaves the chat.</i>`);
+    console.log("unloaded!");
+}
+
+function onLoad() {
+    unloaded = false;
+    sendMessage(`<i>${userName} enters the chat.</i>`);
+    console.log("loaded!");
+}
+
+function checkLocation() {
+    unloaded = !(window.location.pathname == "/chat");
+    if (_unloaded != unloaded) {
+        [onLoad, onUnload][+unloaded](); // a cursed if block
+        _unloaded = unloaded;
+    }
+}
+
+function init() {
+    window.addEventListener("beforeunload", function (event) {
+        // FIXME: sometimes this doesn't emit properly
+        if (window.location.pathname == "/chat") onUnload();
+    });
+    // set socket
+    socket = isWasteof3 ? window.socket : $nuxt.$socket;
+    // add @ to wasteof2 users
+    if (!isWasteof3) userName = "@" + userName;
+    if (socket === undefined) throw Error("socket is undefined");
+    console.log("notify script injected successfully");
+    setInterval(checkLocation, 1000)
+}
+
+init();
+

--- a/background/background.js
+++ b/background/background.js
@@ -19,6 +19,7 @@ async function doesContentScriptExist (tabId, contentScript) {
 }
 
 function runAddon (tabId, contentScript) {
+  console.log(`running ${contentScript} on tab ID ${tabId}`)
   chrome.scripting.executeScript({
     target: { tabId },
     files: ['addons/' + contentScript + '/addon.js']

--- a/manifest_firefox.json
+++ b/manifest_firefox.json
@@ -27,6 +27,21 @@
       "default_popup": "popups/popup.html"
     },
     "host_permissions": ["<all_urls>"],
+    "permission": [
+        "notifications",
+        "tabs",
+        "idle",
+        "webNavigation",
+        "webRequest",
+        "webRequestBlocking",
+        "unlimitedStorage",
+        "storage",
+        "contextMenus",
+        "clipboardWrite",
+        "cookies",
+        "downloads",
+        "<all_urls>"
+    ],
     "web_accessible_resources": [{
         "matches": ["*://*.wasteof.money/*"],
         "resources": [


### PR DESCRIPTION
This PR adds the `chatPresenceNotify` add-on, which posts a message when a user enters/leaves the chat. It's based on [this gist](https://gist.github.com/Gilbert189/ab04381364c49078a3f12d9017338fd7) I made a while back.

Currently it's has some problems working on Firefox due to some permission error that I currently cannot resolve, so testing is done on Chrome at my other laptop.

### Things to do before merging
- [x] Find out another way to get `$socket` (or `socket`)

### Things we could do before merging
- [ ] Fix the permission error (for Firefox)
- [ ] Fix the intermittent to failure to call of `onUnload()` before closing tab (is this browser related?)