### PR TITLE
Make polls work in other places

### DIFF
--- a/addons/polls/addon.js
+++ b/addons/polls/addon.js
@@ -83,9 +83,10 @@ function addon () {
 
   document.querySelectorAll('.prose > pre').forEach(async (element) => {
     const rawContent = element.textContent
-    const postId = element.parentElement.parentElement
-      .getAttribute('to')
-      .replace(/^\/posts\//, '')
+    const postId = (
+      element.parentElement.parentElement.getAttribute('to') ||
+      element.parentElement.parentElement.getAttribute('href')
+    ).replace(/^\/posts\//, '')
     if (!rawContent.startsWith('poll: ')) {
       return
     }


### PR DESCRIPTION
I had an oversight which led to polls only being shown as such when you were on the post itself. It now works in other places as well (like messages, a profile, reposts).