### PR TITLE
Make Build Scripts compatible with Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "wasteof.plus",
-  "version": "0.1.0",
+  "version": "0.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wasteof.plus",
-      "version": "0.1.0",
+      "version": "0.2.3",
       "license": "BSD",
       "dependencies": {
         "flowbite": "^1.7.0",
+        "run-script-os": "^1.1.6",
         "socket.io-client": "^4.7.1",
         "tailwindcss": "^3.3.3"
       },
@@ -2456,6 +2457,15 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/run-script-os": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/run-script-os/-/run-script-os-1.1.6.tgz",
+      "integrity": "sha512-ql6P2LzhBTTDfzKts+Qo4H94VUKpxKDFz6QxxwaUZN0mwvi7L3lpOI7BqPCq7lgDh3XLl0dpeXwfcVIitlrYrw==",
+      "bin": {
+        "run-os": "index.js",
+        "run-script-os": "index.js"
+      }
+    },
     "node_modules/safe-regex-test": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
@@ -4669,6 +4679,11 @@
       "requires": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "run-script-os": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/run-script-os/-/run-script-os-1.1.6.tgz",
+      "integrity": "sha512-ql6P2LzhBTTDfzKts+Qo4H94VUKpxKDFz6QxxwaUZN0mwvi7L3lpOI7BqPCq7lgDh3XLl0dpeXwfcVIitlrYrw=="
     },
     "safe-regex-test": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
     "build:chrome": "run-script-os",
     "build:chrome:windows": "copy manifest_chromium.json manifest.json",
     "build:chrome:linux": "cp manifest_chromium.json manifest.json",
+    "build:chrome:default": "run-script-os",
     "build:firefox": "run-script-os",
     "build:firefox:linux": "cp manifest_firefox.json manifest.json",
-    "build:firefox:windows": "copy manifest_firefox.json manifest.json"
+    "build:firefox:windows": "copy manifest_firefox.json manifest.json",
+    "build:firefox:default": "cp manifest_firefox.json manifest.json",
   },
   "author": "",
   "license": "BSD",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,12 @@
   "description": "",
   "main": "background/background.js",
   "scripts": {
-    "build:chrome": "cp manifest_chromium.json manifest.json",
-    "build:firefox": "cp manifest_firefox.json manifest.json"
+    "build:chrome": "run-script-os",
+    "build:chrome:windows": "copy manifest_chromium.json manifest.json",
+    "build:chrome:linux": "cp manifest_chromium.json manifest.json",
+    "build:firefox": "run-script-os",
+    "build:firefox:linux": "cp manifest_firefox.json manifest.json",
+    "build:firefox:windows": "copy manifest_firefox.json manifest.json"
   },
   "author": "",
   "license": "BSD",
@@ -18,6 +22,7 @@
   },
   "dependencies": {
     "flowbite": "^1.7.0",
+    "run-script-os": "^1.1.6",
     "socket.io-client": "^4.7.1",
     "tailwindcss": "^3.3.3"
   }


### PR DESCRIPTION
This PR basically adds a new dependency, `run-script-os`, which allows the package.json scripts to be run according to platform. Things I need to do:
- [x] Make it work for Linux
- [x] Make it work for Windows
- [x] Make it work for Other (MacOS, other cp-supporting platforms)